### PR TITLE
Feature: Password Change and Password Reset with Token Validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ backports.zoneinfo==0.2.1
 Django==4.2.11
 django-cors-headers==4.3.1
 django-rest-framework==0.1.0
+django-rest-passwordreset==1.4.0
 djangorestframework==3.15.1
 PyJWT==2.8.0
 sqlparse==0.4.4

--- a/sch_finder/settings.py
+++ b/sch_finder/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'rest_framework',
     'sch_finder_api',
+    'django_rest_passwordreset',
 ]
 
 MIDDLEWARE = [
@@ -128,3 +129,12 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 AUTH_USER_MODEL = "sch_finder_api.User"
 CORS_ORIGIN_ALLOW_ALL = True
 CORS_ALLOW_CREDENTIALS =True
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com'
+EMAIL_HOST_USER = 'okpegodwinfather@gmail.com'
+EMAIL_HOST_PASSWORD = 'gusi rpln eecd gbvb'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+
+DEFUALT_FROM_EMAIL = 'okpegodwinfather@gmail.com'

--- a/sch_finder/urls.py
+++ b/sch_finder/urls.py
@@ -21,6 +21,6 @@ from sch_finder_api import urls as finder_urls
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    # path('api-auth/', include('rest_framework.urls')),
     path('api/', include(finder_urls)),
+    path('api/password_reset/', include('django_rest_passwordreset.urls', namespace='password_reset')),
 ]

--- a/sch_finder_api/apps.py
+++ b/sch_finder_api/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class SchFinderApiConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'sch_finder_api'
+
+    def ready(self):
+        import sch_finder_api.signals

--- a/sch_finder_api/data.txt
+++ b/sch_finder_api/data.txt
@@ -13,6 +13,14 @@ Register User:
 "password": "thomascook"
 }
 
+{
+"first_name": "Nathan",
+"last_name": "Jordan",
+"email": "kohat69384@shaflyn.com",
+"password": "thomascook"
+changedpassword: "tester1234"
+}
+"pass
 Editing:
 {
 "first_name": "Correct nancy",
@@ -26,6 +34,13 @@ Login:
 "password": "tired@mail.com"
 }
 
+Password change :
+{
+"old_password": "tired@mail.com",
+"new_password": "ChangedPassword1"
+  }
+
+
 Scholarship:
 
   {
@@ -33,5 +48,14 @@ Scholarship:
     "address": "Lagos, Nigeria",
     "email": "mail@unilag.com",
     "website": "www.unilag.edu.ng",
+    "phone_number": "8122694518"
+  }
+
+School:
+{
+    "name": "Jesus Igwe High School",
+    "address": "Bethlehem, Judea",
+    "email": "mail@beth.lehem",
+    "website": "www.jesusislord.ng",
     "phone_number": "8122694518"
   }

--- a/sch_finder_api/serializer.py
+++ b/sch_finder_api/serializer.py
@@ -18,7 +18,6 @@ class UserSerializer(serializers.Serializer):
 class UserEditSerializer(serializers.Serializer):
     first_name = serializers.CharField()
     last_name = serializers.CharField()
-    password = serializers.CharField(write_only=True)
 
 
 class SchoolSerializer(serializers.Serializer):
@@ -60,3 +59,12 @@ class EditScholarshipSerializer(serializers.Serializer):
     benefit = serializers.CharField()
     requirement = serializers.CharField()
     link = serializers.CharField()
+
+
+class ChangePasswordSerializer(serializers.Serializer):
+    old_password = serializers.CharField(required=True)
+    new_password = serializers.CharField(required=True)
+
+
+class ResetPasswordEmailSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=True)

--- a/sch_finder_api/services.py
+++ b/sch_finder_api/services.py
@@ -53,8 +53,8 @@ def edit_user(user: "User", data):
     user.first_name = data["first_name"]
     user.last_name = data["last_name"]
 
-    if data["password"] is not None:
-        user.set_password(data["password"])
+    # if data["password"] is not None:
+    #     user.set_password(data["password"])
 
     user.save()
 

--- a/sch_finder_api/signals.py
+++ b/sch_finder_api/signals.py
@@ -1,0 +1,29 @@
+from django.core.mail import EmailMultiAlternatives
+from django.dispatch import receiver
+from django.urls import reverse
+from django_rest_passwordreset.signals import reset_password_token_created
+from django.conf import settings
+from rest_framework.reverse import reverse_lazy
+
+@receiver(reset_password_token_created)
+def password_reset_token_created(sender, instance, reset_password_token, *args, **kwargs):
+    # Construct the reset password URL
+    reset_password_url = "{}?token={}".format(
+    instance.request.build_absolute_uri(reverse_lazy('password_reset:reset-password-confirm')),
+    reset_password_token.key
+)
+
+    # Construct the email content
+    email_message = f"Click the following link to reset your password: {reset_password_url}"
+
+    msg = EmailMultiAlternatives(
+        # title:
+        "Password Reset for School Finder",
+        # message:
+        email_message,
+        # from:
+        settings.DEFAULT_FROM_EMAIL,
+        # to:
+        [reset_password_token.user.email]
+    )
+    msg.send()

--- a/sch_finder_api/urls.py
+++ b/sch_finder_api/urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
     path("me/", views.UserApi.as_view(), name="profile_update"),
     path("me/", views.UserApi.as_view(), name="profile_delete"),
     path("logout/", views.LogoutApi.as_view(), name="logout"),
-    path("school/", views.SchoolApi.as_view(), name="create_sch"),
+    path("schools/", views.SchoolApi.as_view(), name="create_sch"),
     path("schools/", views.SchoolApi.as_view(), name="get_sch"),
     path('schools/<int:id>/', views.SchoolApi.as_view(), name='delete_school'),
     path('schools/<int:id>/', views.SchoolApi.as_view(), name='edit_school'),
@@ -16,5 +16,6 @@ urlpatterns = [
     path("scholarships/", views.ScholarshipApi.as_view(), name="get_scholarship"),
     path("scholarships/<int:id>/", views.ScholarshipApi.as_view(), name="update_scholarship"),
     path("scholarships/", views.ScholarshipApi.as_view(), name="delete_scholarship"),
+    path("change_password/",views.ChangePassword.as_view(), name="change_password"),
 
 ]

--- a/sch_finder_api/views.py
+++ b/sch_finder_api/views.py
@@ -1,6 +1,6 @@
 from rest_framework import views, response, exceptions, permissions, status
 
-from .serializer import UserSerializer, UserEditSerializer, SchoolSerializer, EditSchoolSerializer, ScholarshipSerializer, EditScholarshipSerializer
+from .serializer import UserSerializer, UserEditSerializer, SchoolSerializer, EditSchoolSerializer, ScholarshipSerializer, EditScholarshipSerializer, ChangePasswordSerializer
 from . import services, authentication
 from .models import School, Scholarship
 
@@ -143,3 +143,18 @@ class ScholarshipApi(views.APIView):
         schship_update = services.update_scholarship(id, data)
         return response.Response({"message": "Successful"})
 
+class ChangePassword(views.APIView):
+    authentication_classes = (authentication.CustomUserAuthentication, )
+    permission_classes = (permissions.IsAuthenticated, )
+
+    def post(self, request):
+        user = request.user
+        serializer = ChangePasswordSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = request.user
+        if user.check_password(serializer.data.get('old_password')):
+            user.set_password(serializer.data.get('new_password'))
+            user.save()
+            return response.Response({'message': 'Password changed successfully.'}, status=status.HTTP_200_OK)
+        return response.Response({'error': 'Incorrect old password.'}, status=status.HTTP_400_BAD_REQUEST)
+    


### PR DESCRIPTION
Added the Change password endpoint and also the reset password endpoint with tokens created and validated using the django-rest-passwordreset library.

I used gmail smtp to send the email. Tested and working fine.